### PR TITLE
Differentiate regular queries from relationship queries.

### DIFF
--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -198,7 +198,8 @@ impl Components {
                 name: layout.name,
             });
         }
-        self.relationship_indices.insert(layout.type_id().unwrap(), id);
+        self.relationship_indices
+            .insert(layout.type_id().unwrap(), id);
         self.kinds.push(RelationKindInfo { data: layout, id });
         Ok(self.kinds.last().unwrap())
     }

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -170,6 +170,7 @@ pub struct Components {
     // use their own hashmap to lookup CustomId -> RelationKindId
     component_indices: HashMap<TypeId, RelationKindId, fxhash::FxBuildHasher>,
     resource_indices: HashMap<TypeId, RelationKindId, fxhash::FxBuildHasher>,
+    relationship_indices: HashMap<TypeId, RelationKindId, fxhash::FxBuildHasher>,
 }
 
 #[derive(Debug, Error)]
@@ -178,14 +179,28 @@ pub enum RelationsError {
     ComponentAlreadyExists { type_id: TypeId, name: String },
     #[error("A resource of type {name:?} ({type_id:?}) already exists")]
     ResourceAlreadyExists { type_id: TypeId, name: String },
+    #[error("A relation of type {name:?} ({type_id:?}) already exists")]
+    RelationshipAlreadyExists { type_id: TypeId, name: String },
 }
 
 impl Components {
-    pub fn new_relation_kind(&mut self, layout: ComponentDescriptor) -> &RelationKindInfo {
-        assert!(layout.type_id.is_none());
+    pub fn new_relationship_kind(
+        &mut self,
+        layout: ComponentDescriptor,
+    ) -> Result<&RelationKindInfo, RelationsError> {
         let id = RelationKindId(self.kinds.len());
+        if self
+            .relationship_indices
+            .contains_key(&layout.type_id().unwrap())
+        {
+            return Err(RelationsError::RelationshipAlreadyExists {
+                type_id: layout.type_id().unwrap(),
+                name: layout.name,
+            });
+        }
+        self.relationship_indices.insert(layout.type_id().unwrap(), id);
         self.kinds.push(RelationKindInfo { data: layout, id });
-        self.kinds.last().unwrap()
+        Ok(self.kinds.last().unwrap())
     }
 
     pub fn new_component_kind(
@@ -238,6 +253,25 @@ impl Components {
     pub fn get_resource_kind(&self, type_id: TypeId) -> Option<&RelationKindInfo> {
         let id = self.resource_indices.get(&type_id).copied()?;
         Some(&self.kinds[id.0])
+    }
+
+    pub fn get_relationship_kind(&self, type_id: TypeId) -> Option<&RelationKindInfo> {
+        let id = self.relationship_indices.get(&type_id).copied()?;
+        Some(&self.kinds[id.0])
+    }
+
+    pub fn get_relationship_kind_or_insert(
+        &mut self,
+        layout: ComponentDescriptor,
+    ) -> &RelationKindInfo {
+        match self
+            .relationship_indices
+            .get(&layout.type_id().unwrap())
+            .copied()
+        {
+            Some(kind) => &self.kinds[kind.0],
+            None => self.new_relationship_kind(layout).unwrap(),
+        }
     }
 
     pub fn get_component_kind_or_insert(

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -671,7 +671,7 @@ unsafe impl<T: Component> FetchState for ReadRelationState<T> {
     fn init(world: &mut World) -> Self {
         let kind_info = world
             .components
-            .get_component_kind_or_insert(ComponentDescriptor::new::<T>(StorageType::Table));
+            .get_relationship_kind_or_insert(ComponentDescriptor::new::<T>(StorageType::Table));
 
         Self {
             p: PhantomData,
@@ -952,7 +952,7 @@ unsafe impl<T: Component> FetchState for WriteRelationState<T> {
     fn init(world: &mut World) -> Self {
         let kind_info = world
             .components
-            .get_component_kind_or_insert(ComponentDescriptor::new::<T>(StorageType::Table));
+            .get_relationship_kind_or_insert(ComponentDescriptor::new::<T>(StorageType::Table));
 
         Self {
             p: PhantomData,

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -351,7 +351,7 @@ unsafe impl<T: Component> FetchState for WithoutRelationState<T> {
     fn init(world: &mut World) -> Self {
         let kind_info = world
             .components
-            .get_component_kind_or_insert(ComponentDescriptor::new::<T>(StorageType::Table));
+            .get_relationship_kind_or_insert(ComponentDescriptor::new::<T>(StorageType::Table));
 
         Self {
             marker: PhantomData,
@@ -492,7 +492,7 @@ unsafe impl<T: Component> FetchState for WithRelationState<T> {
     fn init(world: &mut World) -> Self {
         let kind_info = world
             .components
-            .get_component_kind_or_insert(ComponentDescriptor::new::<T>(StorageType::Table));
+            .get_relationship_kind_or_insert(ComponentDescriptor::new::<T>(StorageType::Table));
 
         Self {
             marker: PhantomData,

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -391,6 +391,8 @@ impl SparseSets {
         self.relation_sets.get(relation_kind)
     }
 
+    // FIXME(Relationships): https://discord.com/channels/691052431525675048/749335865876021248/862199702825205760
+    // FIXME(Relationships): Deal with the ability to register components with a target, and relations without one
     pub fn get_or_insert(
         &mut self,
         relation_kind: &RelationKindInfo,

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -624,15 +624,15 @@ mod tests {
         queue.apply(&mut world);
 
         let e1 = world.entity(e1);
-        assert_eq!(e1.get_relation::<MyRelation>(Some(t1)).unwrap().0, true);
-        assert_eq!(e1.get_relation::<MyRelation>(Some(t2)).unwrap().0, false);
-        assert_eq!(e1.get_relation::<MyRelationTwo>(Some(t3)).unwrap().0, 18);
+        assert_eq!(e1.get_relation::<MyRelation>(t1).unwrap().0, true);
+        assert_eq!(e1.get_relation::<MyRelation>(t2).unwrap().0, false);
+        assert_eq!(e1.get_relation::<MyRelationTwo>(t3).unwrap().0, 18);
         let e1 = e1.id();
 
         let e2 = world.entity(e2);
-        assert_eq!(e2.get_relation::<MyRelation>(Some(t3)).unwrap().0, false);
-        assert_eq!(e2.get_relation::<MyRelationTwo>(Some(t1)).unwrap().0, 10);
-        assert_eq!(e2.get_relation::<MyRelation>(Some(t1)).unwrap().0, false);
+        assert_eq!(e2.get_relation::<MyRelation>(t3).unwrap().0, false);
+        assert_eq!(e2.get_relation::<MyRelationTwo>(t1).unwrap().0, 10);
+        assert_eq!(e2.get_relation::<MyRelation>(t1).unwrap().0, false);
         let e2 = e2.id();
 
         let mut commands = Commands::new(&mut queue, &world);
@@ -643,13 +643,7 @@ mod tests {
         drop(commands);
         queue.apply(&mut world);
 
-        assert!(world
-            .entity(e1)
-            .get_relation::<MyRelation>(Some(t2))
-            .is_none());
-        assert!(world
-            .entity(e2)
-            .get_relation::<MyRelation>(Some(t3))
-            .is_none());
+        assert!(world.entity(e1).get_relation::<MyRelation>(t2).is_none());
+        assert!(world.entity(e2).get_relation::<MyRelation>(t3).is_none());
     }
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -982,7 +982,7 @@ pub(crate) unsafe fn get_relationship_and_ticks_with_type(
     entity: Entity,
     location: EntityLocation,
 ) -> Option<(*mut u8, *mut ComponentTicks)> {
-    let kind_info = world.components.get_component_kind(type_id)?;
+    let kind_info = world.components.get_relationship_kind(type_id)?;
     get_component_and_ticks(world, kind_info.id(), Some(target), entity, location)
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -190,15 +190,7 @@ impl World {
         &mut self,
         descriptor: ComponentDescriptor,
     ) -> Result<RelationKindId, RelationsError> {
-        let storage_type = descriptor.storage_type();
-        let relation_kind = self.components.new_relationship_kind(descriptor)?;
-
-        // ensure sparse set is created for SparseSet components
-        if storage_type == StorageType::SparseSet {
-            self.storages.sparse_sets.get_or_insert(relation_kind, None);
-        }
-
-        Ok(relation_kind.id())
+        Ok(self.components.new_relationship_kind(descriptor)?.id())
     }
 
     /// Retrieves an [EntityRef] that exposes read-only operations for the given `entity`.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -169,6 +169,38 @@ impl World {
         Ok(relation_kind.id())
     }
 
+    /// Registers a new relation using the given [ComponentDescriptor]. Relations do not need to
+    /// be manually registered. This just provides a way to override default configuration.
+    /// Attempting to register a relation with a type that has already been used by [World]
+    /// will result in an error.
+    ///
+    /// The default component storage type can be overridden like this:
+    ///
+    /// ```
+    /// use bevy_ecs::{component::{ComponentDescriptor, StorageType}, world::World};
+    ///
+    /// struct MyRelation {
+    ///   weight: f32,
+    /// }
+    ///
+    /// let mut world = World::new();
+    /// world.register_relation(ComponentDescriptor::new::<MyRelation>(StorageType::SparseSet)).unwrap();
+    /// ```
+    pub fn register_relation(
+        &mut self,
+        descriptor: ComponentDescriptor,
+    ) -> Result<RelationKindId, RelationsError> {
+        let storage_type = descriptor.storage_type();
+        let relation_kind = self.components.new_relationship_kind(descriptor)?;
+
+        // ensure sparse set is created for SparseSet components
+        if storage_type == StorageType::SparseSet {
+            self.storages.sparse_sets.get_or_insert(relation_kind, None);
+        }
+
+        Ok(relation_kind.id())
+    }
+
     /// Retrieves an [EntityRef] that exposes read-only operations for the given `entity`.
     /// This will panic if the `entity` does not exist. Use [World::get_entity] if you want
     /// to check for entity existence instead of implicitly panic-ing.

--- a/crates/bevy_ecs/src/world/tests.rs
+++ b/crates/bevy_ecs/src/world/tests.rs
@@ -18,7 +18,7 @@ fn relation_spawn_raw(storage_type: StorageType) {
     let mut world = World::new();
 
     world
-        .register_component(ComponentDescriptor::new::<ChildOf>(storage_type))
+        .register_relation(ComponentDescriptor::new::<ChildOf>(storage_type))
         .unwrap();
 
     struct ChildOf;
@@ -50,7 +50,7 @@ fn relation_query_raw(storage_type: StorageType) {
     let mut world = World::new();
 
     world
-        .register_component(ComponentDescriptor::new::<ChildOf>(storage_type))
+        .register_relation(ComponentDescriptor::new::<ChildOf>(storage_type))
         .unwrap();
 
     let parent1 = world.spawn().id();
@@ -103,7 +103,7 @@ fn relation_access_raw(storage_type: StorageType) {
     let mut world = World::new();
 
     world
-        .register_component(ComponentDescriptor::new::<ChildOf>(storage_type))
+        .register_relation(ComponentDescriptor::new::<ChildOf>(storage_type))
         .unwrap();
 
     let random_parent = world.spawn().id();
@@ -241,7 +241,7 @@ fn relation_query_mut_raw(storage_type: StorageType) {
 
     let mut world = World::new();
     world
-        .register_component(ComponentDescriptor::new::<MyRelation>(storage_type))
+        .register_relation(ComponentDescriptor::new::<MyRelation>(storage_type))
         .unwrap();
 
     let target1 = world.spawn().insert(Fragment::<1>).id();
@@ -512,7 +512,7 @@ fn without_filter() {
 fn without_filter_raw(storage_type: StorageType) {
     let mut world = World::new();
     world
-        .register_component(ComponentDescriptor::new::<u32>(storage_type))
+        .register_relation(ComponentDescriptor::new::<u32>(storage_type))
         .unwrap();
 
     struct MyRelation;
@@ -563,7 +563,7 @@ fn relations_dont_yield_components_raw(storage_type: StorageType) {
     let mut world = World::new();
 
     world
-        .register_component(ComponentDescriptor::new::<u32>(storage_type))
+        .register_relation(ComponentDescriptor::new::<u32>(storage_type))
         .unwrap();
 
     let _has_component = world.spawn().insert(10_u32).id();
@@ -603,7 +603,7 @@ fn duplicated_target_filters_raw(storage_type: StorageType) {
     let mut world = World::new();
 
     world
-        .register_component(ComponentDescriptor::new::<u32>(storage_type))
+        .register_relation(ComponentDescriptor::new::<u32>(storage_type))
         .unwrap();
 
     let target = world.spawn().id();
@@ -635,7 +635,7 @@ fn with_filter() {
 fn with_filter_raw(storage_type: StorageType) {
     let mut world = World::new();
     world
-        .register_component(ComponentDescriptor::new::<u32>(storage_type))
+        .register_relation(ComponentDescriptor::new::<u32>(storage_type))
         .unwrap();
 
     let no_relation = world.spawn().insert(10_u32).id();

--- a/crates/bevy_ecs/src/world/tests.rs
+++ b/crates/bevy_ecs/src/world/tests.rs
@@ -399,9 +399,10 @@ macro_rules! self_query_conflict_tests {
     };
 }
 
-// FIXME(Relationships) components and relations should no longer conflict
 self_query_conflict_tests!(
     mut_and_mut => <(&mut Relation<u32>, &mut Relation<u32>)>
+    mut_and_ref => <(&mut Relation<u32>, &Relation<u32>)>
+    ref_and_mut => <(&mut Relation<u32>, &Relation<u32>)>
 );
 
 macro_rules! no_self_query_conflict_tests {

--- a/crates/bevy_ecs/src/world/tests.rs
+++ b/crates/bevy_ecs/src/world/tests.rs
@@ -684,3 +684,36 @@ fn with_filter_raw(storage_type: StorageType) {
         .try_into()
         .unwrap();
 }
+
+#[test]
+pub fn sparse_set_relation_registration() {
+    let mut world = World::new();
+    world
+        .register_relation(ComponentDescriptor::new::<String>(StorageType::SparseSet))
+        .unwrap();
+    let mut q = world.query::<&Relation<String>>();
+    assert!(q.iter(&world).next().is_none());
+
+    let target = world.spawn().id();
+    world
+        .spawn()
+        .insert_relation(String::from("UwowU"), target)
+        .id();
+
+    use std::any::TypeId;
+    let ty_id = world
+        .components
+        .get_relationship_kind(TypeId::of::<String>())
+        .unwrap()
+        .id();
+
+    assert_eq!(
+        world
+            .storages
+            .sparse_sets
+            .get(ty_id, Some(target))
+            .unwrap()
+            .len(),
+        1
+    );
+}

--- a/crates/bevy_ecs/src/world/tests.rs
+++ b/crates/bevy_ecs/src/world/tests.rs
@@ -402,12 +402,6 @@ macro_rules! self_query_conflict_tests {
 // FIXME(Relationships) components and relations should no longer conflict
 self_query_conflict_tests!(
     mut_and_mut => <(&mut Relation<u32>, &mut Relation<u32>)>
-    mut_and_rel_mut => <(&mut u32, &mut Relation<u32>)>
-    rel_mut_and_mut => <(&mut Relation<u32>, &mut u32)>
-    rel_and_mut => <(&Relation<u32>, &mut u32)>
-    mut_and_rel => <(&mut u32, &Relation<u32>)>
-    rel_mut_and_ref => <(&mut Relation<u32>, &u32)>
-    ref_and_rel_mut => <(&u32, &mut Relation<u32>)>
 );
 
 macro_rules! no_self_query_conflict_tests {
@@ -423,6 +417,12 @@ macro_rules! no_self_query_conflict_tests {
 }
 
 no_self_query_conflict_tests!(
+    rel_and_mut => <(&Relation<u32>, &mut u32)>
+    mut_and_rel => <(&mut u32, &Relation<u32>)>
+    rel_mut_and_ref => <(&mut Relation<u32>, &u32)>
+    ref_and_rel_mut => <(&u32, &mut Relation<u32>)>
+    mut_and_rel_mut => <(&mut u32, &mut Relation<u32>)>
+    rel_mut_and_mut => <(&mut Relation<u32>, &mut u32)>
     rel_and_rel => <(&Relation<u32>, &Relation<u32>)>
     rel_and_diff_rel => <(&Relation<u32>, &Relation<u64>)>
     rel_mut_and_diff_rel_mut => <(&mut Relation<u32>, &mut Relation<u64>)>


### PR DESCRIPTION
Allows stuff like `Query<(&mut T, &mut Relation<T>)>` to exist.